### PR TITLE
Remove Lovable references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,16 @@
-# Welcome to your Lovable project
+# Welcome to your Braille Drawing Editor
 
 ## Project info
 
-**URL**: https://lovable.dev/projects/6fe20dc8-ead4-4074-a47e-d07fedc80954
 
 ## How can I edit this code?
 
 There are several ways of editing your application.
 
-**Use Lovable**
-
-Simply visit the [Lovable Project](https://lovable.dev/projects/6fe20dc8-ead4-4074-a47e-d07fedc80954) and start prompting.
-
-Changes made via Lovable will be committed automatically to this repo.
 
 **Use your preferred IDE**
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+If you want to work locally using your own IDE, you can clone this repo and push changes.
 
 The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
@@ -62,12 +56,6 @@ This project is built with:
 
 ## How can I deploy this project?
 
-Simply open [Lovable](https://lovable.dev/projects/6fe20dc8-ead4-4074-a47e-d07fedc80954) and click on Share -> Publish.
+Run `npm run build` to generate the production files. You can then host the contents of the `dist/` directory on any static hosting service.
 
-## Can I connect a custom domain to my Lovable project?
 
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)

--- a/index.html
+++ b/index.html
@@ -5,16 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Editor de Desenho Braille</title>
     <meta name="description" content="Ferramenta para criar desenhos em formato braille" />
-    <meta name="author" content="Lovable" />
 
-    <meta property="og:title" content="6fe20dc8-ead4-4074-a47e-d07fedc80954" />
-    <meta property="og:description" content="Lovable Generated Project" />
+    <meta property="og:title" content="Editor de Desenho Braille" />
+    <meta property="og:description" content="Ferramenta para criar desenhos em formato braille" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
-    "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -11,8 +10,6 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&
-    componentTagger(),
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- scrub all mentions of Lovable from the README
- clean up Lovable meta tags and text in `index.html`
- drop `lovable-tagger` dependency and plugin

## Testing
- `npm run lint` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e89914bb083298f6b8bb1ae1cb288